### PR TITLE
feat: Download Near validator data from RPC node

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,8 @@
 [workspace]
 
 members = [
-    "sim-validator-assignment"
+    "dl-validator-data",
+    "sim-validator-assignment",
 ]
 
 [profile.dev.package]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,16 @@ members = [
     "sim-validator-assignment",
 ]
 
+[workspace.dependencies]
+anyhow = "1.0"
+clap = { version = "4.4.2", features = ["derive"] }
+fastrand = "2.0"
+insta = { version = "1.31.0", features = ["yaml"] }
+num-rational = {version="0.4", features = ["serde"]}
+reqwest = { version = "0.11", features = ["blocking", "json"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
 [profile.dev.package]
 # Optimizing `insta` and `similar` is recommended for faster runs.
 # https://insta.rs/docs/quickstart/#optional-faster-runs

--- a/dl-validator-data/Cargo.toml
+++ b/dl-validator-data/Cargo.toml
@@ -10,3 +10,6 @@ anyhow = "1.0"
 reqwest = { version = "0.11", features = ["blocking", "json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+
+[dev-dependencies]
+insta = { version = "1.31.0", features = ["yaml"] }

--- a/dl-validator-data/Cargo.toml
+++ b/dl-validator-data/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0"
-reqwest = { version = "0.11", features = ["blocking", "json"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+anyhow.workspace = true
+reqwest.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 
 [dev-dependencies]
-insta = { version = "1.31.0", features = ["yaml"] }
+insta.workspace = true

--- a/dl-validator-data/Cargo.toml
+++ b/dl-validator-data/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "dl-validator-data"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1.0"
+reqwest = { version = "0.11", features = ["blocking", "json"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/dl-validator-data/src/lib.rs
+++ b/dl-validator-data/src/lib.rs
@@ -1,5 +1,5 @@
 mod near;
 mod protocol;
 
-pub use near::NearPrototocl;
+pub use near::NearProtocol;
 pub use protocol::Protocol;

--- a/dl-validator-data/src/lib.rs
+++ b/dl-validator-data/src/lib.rs
@@ -1,0 +1,5 @@
+mod near;
+mod protocol;
+
+pub use near::NearPrototocl;
+pub use protocol::Protocol;

--- a/dl-validator-data/src/near.rs
+++ b/dl-validator-data/src/near.rs
@@ -2,14 +2,14 @@ use serde::Deserialize;
 
 use crate::protocol::{Protocol, ValidatorData};
 
-pub struct NearPrototocl {
+pub struct NearProtocol {
     /// The RPC endpoint to query. See [`Self::new`] for more info.
     rpc_url: String,
     /// The block height for which validator is queried. See [`Self::new`] for more info.
     block: Option<u64>,
 }
 
-impl NearPrototocl {
+impl NearProtocol {
     /// Constructs an instance to download validator data from `rpc_url` for `block_height`.
     ///
     /// Near [RPC docs] list several providers.
@@ -25,7 +25,7 @@ impl NearPrototocl {
     }
 }
 
-impl Protocol for NearPrototocl {
+impl Protocol for NearProtocol {
     /// Downloads Near validator data via the [`validators`] RPC method.
     ///
     /// [`validators`]: https://docs.near.org/api/rpc/network#validation-status
@@ -112,7 +112,7 @@ impl From<RpcValidatorData> for ValidatorData {
 mod tests {
     use crate::protocol::Protocol;
 
-    use super::NearPrototocl;
+    use super::NearProtocol;
 
     const RPC_URL: &str = "https://archival-rpc.testnet.near.org";
     /// Use a constant block in tests to have deterministic results of RPC queries.
@@ -120,7 +120,7 @@ mod tests {
 
     #[test]
     fn test_download_validator_data() -> anyhow::Result<()> {
-        let protocol = NearPrototocl::new(RPC_URL.to_owned(), Some(BLOCK_HEIGHT));
+        let protocol = NearProtocol::new(RPC_URL.to_owned(), Some(BLOCK_HEIGHT));
         let validators = protocol.download_validator_data()?;
 
         // The downloaded `valdiators` should be deterministic since we use a fixed block height.
@@ -135,7 +135,7 @@ mod tests {
     /// test only verifies that validator data was download but does not check the data itself.
     #[test]
     fn test_download_validator_data_latest() -> anyhow::Result<()> {
-        let protocol = NearPrototocl::new(RPC_URL.to_owned(), None);
+        let protocol = NearProtocol::new(RPC_URL.to_owned(), None);
         let validators = protocol.download_validator_data()?;
         assert!(validators.len() > 0);
         Ok(())
@@ -146,7 +146,7 @@ mod tests {
     #[test]
     fn test_rpc_body_error() -> anyhow::Result<()> {
         // Querying a block height that is not the last block in an epoch causes an error.
-        let protocol = NearPrototocl::new(RPC_URL.to_owned(), Some(42));
+        let protocol = NearProtocol::new(RPC_URL.to_owned(), Some(42));
         let err = protocol
             .download_validator_data()
             .expect_err("querying an invalid block should lead to an error");

--- a/dl-validator-data/src/near.rs
+++ b/dl-validator-data/src/near.rs
@@ -114,7 +114,7 @@ mod tests {
 
     use super::NearPrototocl;
 
-    const RPC_URL: &str = "https://rpc.testnet.near.org";
+    const RPC_URL: &str = "https://archival-rpc.testnet.near.org";
     /// Use a constant block in tests to have deterministic results of RPC queries.
     const BLOCK_HEIGHT: u64 = 139491540;
 

--- a/dl-validator-data/src/near.rs
+++ b/dl-validator-data/src/near.rs
@@ -1,0 +1,159 @@
+use serde::Deserialize;
+
+use crate::protocol::{Protocol, ValidatorData};
+
+pub struct NearPrototocl {
+    /// The RPC endpoint to query. See [`Self::new`] for more info.
+    rpc_url: String,
+    /// The block height for which validator is queried. See [`Self::new`] for more info.
+    block: Option<u64>,
+}
+
+impl NearPrototocl {
+    /// Constructs an instance to download validator data from `rpc_url` for `block_height`.
+    ///
+    /// Near [RPC docs] list several providers.
+    ///
+    /// If `block` is `None` data for the latest block will be downloaded. In case a `block_height`
+    /// is provided, it must refer to the last block of an epoch as described in the [RPC method
+    /// docs].
+    ///
+    /// [RPC docs]: https://docs.near.org/api/rpc/providers
+    /// [RPC method docs]: https://docs.near.org/api/rpc/network#validation-status
+    pub fn new(rpc_url: String, block: Option<u64>) -> Self {
+        Self { rpc_url, block }
+    }
+}
+
+impl Protocol for NearPrototocl {
+    /// Downloads Near validator data via the [`validators`] RPC method.
+    ///
+    /// [`validators`]: https://docs.near.org/api/rpc/network#validation-status
+    fn download_validator_data(&self) -> anyhow::Result<Vec<ValidatorData>> {
+        // Construct parameters for the HTTP request to RPC.
+        let params = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "validators",
+            "id": "dontcare",
+            // If `self.block.is_none()` this serializes to `[null]` and latest block is queried.
+            "params": vec![self.block],
+        });
+
+        // Construct and send the HTTP request.
+        let client = reqwest::blocking::Client::new();
+        let res = client.post(&self.rpc_url).json(&params).send()?;
+
+        // Handle HTTP and RPC errors.
+        anyhow::ensure!(
+            res.status() == 200,
+            "expected HTTP status code 200, got {} with response body\n\t{}",
+            res.status(),
+            res.text()?,
+        );
+        let rpc_res: RpcResponse = res.json()?;
+        if let Some(err) = rpc_res.error {
+            anyhow::bail!("rpc error: {}", err);
+        }
+
+        let validators = rpc_res
+            .result
+            .expect("response without error should have a result")
+            .current_validators
+            .into_iter()
+            .map(|v| v.into())
+            .collect();
+
+        Ok(validators)
+    }
+}
+
+/// The expected response for the `validators` RPC method. This struct contains only fields used in
+/// this module. Additional fields are documented in Near RPC [docs].
+///
+/// [docs]: https://docs.near.org/api/rpc/network#validation-status
+#[derive(Deserialize, Debug)]
+struct RpcResponse {
+    result: Option<RpcResult>,
+    /// Near RPC returns some errors in the response body of a 'successful' (status code 200) HTTP
+    /// request.
+    error: Option<serde_json::Value>,
+}
+
+#[derive(Deserialize, Debug)]
+struct RpcResult {
+    current_validators: Vec<RpcValidatorData>,
+}
+
+/// Data per validator returned by the RPC. This struct contains only fields used in
+/// this module. Additional fields are documented in Near RPC [docs].
+///
+/// [docs]: https://docs.near.org/api/rpc/network#validation-status
+#[derive(Deserialize, Debug)]
+struct RpcValidatorData {
+    account_id: String,
+    /// String representation of `u128`.
+    stake: String,
+}
+
+impl From<RpcValidatorData> for ValidatorData {
+    fn from(data: RpcValidatorData) -> Self {
+        Self {
+            account_id: data.account_id,
+            stake: data
+                .stake
+                .parse::<u128>()
+                .expect("should parse stake as u128"),
+            is_malicious: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::protocol::Protocol;
+
+    use super::NearPrototocl;
+
+    const RPC_URL: &str = "https://rpc.testnet.near.org";
+    /// Use a constant block in tests to have deterministic results of RPC queries.
+    const BLOCK_HEIGHT: u64 = 139491540;
+
+    #[test]
+    fn test_download_validator_data() -> anyhow::Result<()> {
+        let protocol = NearPrototocl::new(RPC_URL.to_owned(), Some(BLOCK_HEIGHT));
+        let validators = protocol.download_validator_data()?;
+
+        // The downloaded `valdiators` should be deterministic since we use a fixed block height.
+        assert_eq!(validators.len(), 31);
+        // Looking at a subset of `validators` suffices to test validator data is handled correclty.
+        insta::assert_debug_snapshot!(&validators[..2]);
+
+        Ok(())
+    }
+
+    /// Test querying the latest block. Since the set of active validators changes over time, this
+    /// test only verifies that validator data was download but does not check the data itself.
+    #[test]
+    fn test_download_validator_data_latest() -> anyhow::Result<()> {
+        let protocol = NearPrototocl::new(RPC_URL.to_owned(), None);
+        let validators = protocol.download_validator_data()?;
+        assert!(validators.len() > 0);
+        Ok(())
+    }
+
+    /// Test handling of errors which the RPC sends in the body of a successful (status code 200)
+    /// response.
+    #[test]
+    fn test_rpc_body_error() -> anyhow::Result<()> {
+        // Querying a block height that is not the last block in an epoch causes an error.
+        let protocol = NearPrototocl::new(RPC_URL.to_owned(), Some(42));
+        let err = protocol
+            .download_validator_data()
+            .expect_err("querying an invalid block should lead to an error");
+        insta::assert_debug_snapshot!(
+            // Verify getting the expected error message.
+            err
+        );
+        Ok(())
+    }
+}

--- a/dl-validator-data/src/protocol.rs
+++ b/dl-validator-data/src/protocol.rs
@@ -1,3 +1,5 @@
+use serde::Deserialize;
+
 /// A trait that can be implemented for different blockchain protocols which allow downloading
 /// validator data that can be feed into a simulation of validator assignment.
 pub trait Protocol {
@@ -6,6 +8,7 @@ pub trait Protocol {
 }
 
 /// The information per validator required to run a simulation.
+#[derive(Deserialize, Debug)]
 pub struct ValidatorData {
     pub account_id: String,
     pub stake: u128,

--- a/dl-validator-data/src/protocol.rs
+++ b/dl-validator-data/src/protocol.rs
@@ -1,0 +1,15 @@
+/// A trait that can be implemented for different blockchain protocols which allow downloading
+/// validator data that can be feed into a simulation of validator assignment.
+pub trait Protocol {
+    /// Download validator data from a service like a RPC node.
+    fn download_validator_data(&self) -> anyhow::Result<Vec<ValidatorData>>;
+}
+
+/// The information per validator required to run a simulation.
+pub struct ValidatorData {
+    pub account_id: String,
+    pub stake: u128,
+    /// In case downloaded validator contains no information whether a node is malicious this is
+    /// `None`.
+    pub is_malicious: Option<bool>,
+}

--- a/dl-validator-data/src/snapshots/dl_validator_data__near__tests__download_validator_data.snap
+++ b/dl-validator-data/src/snapshots/dl_validator_data__near__tests__download_validator_data.snap
@@ -1,0 +1,16 @@
+---
+source: dl-validator-data/src/near.rs
+expression: "&validators[..2]"
+---
+[
+    ValidatorData {
+        account_id: "node1",
+        stake: 46520997523084461567575091770703,
+        is_malicious: None,
+    },
+    ValidatorData {
+        account_id: "node2",
+        stake: 46515725866196237909861376673130,
+        is_malicious: None,
+    },
+]

--- a/dl-validator-data/src/snapshots/dl_validator_data__near__tests__rpc_body_error.snap
+++ b/dl-validator-data/src/snapshots/dl_validator_data__near__tests__rpc_body_error.snap
@@ -1,0 +1,5 @@
+---
+source: dl-validator-data/src/near.rs
+expression: err
+---
+"rpc error: {\"cause\":{\"name\":\"UNKNOWN_EPOCH\"},\"code\":-32000,\"data\":\"Unknown Epoch\",\"message\":\"Server error\",\"name\":\"HANDLER_ERROR\"}"

--- a/sim-validator-assignment/Cargo.toml
+++ b/sim-validator-assignment/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0"
-clap = { version = "4.4.2", features = ["derive"] }
-fastrand = "2.0"
-num-rational = {version="0.4", features = ["serde"]}
-serde = { version = "1.0", features = ["derive"] }
+anyhow.workspace = true
+clap.workspace = true
+fastrand.workspace = true
+num-rational.workspace = true
+serde.workspace = true
 
 [dev-dependencies]
-insta = { version = "1.31.0", features = ["yaml"] }
+insta.workspace = true


### PR DESCRIPTION
The download is implemented in `dl-validator-data` by implementing the `Protocol` trait. The purpose of abstraction via a trait is facilitating the download of validator data for other blockchains. To support downloading data of another blockchain and use it in simulations, it should suffice to implement the `Protocol` trait.

## Next steps

- Add a CLI command for downloading `NearProtocol` validator data and storing it in a file. To mark some validators as malicious, users can edit the file.
- Extend the existing command that runs a simulation to read validator data from a file.

I would propose to implement that in separate PR(s).