### PR TITLE
feat!: support subcommands and add `download` subcommand

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+.PHONY: run
 run:
 	cargo run -p sim-validator-assignment -- \
 		run \
@@ -7,6 +8,7 @@ run:
 		--stake-per-seat 1 \
 		--max-malicious-stake-per-shard 1/2
 
+.PHONY: download
 download:
 	cargo run -p sim-validator-assignment -- \
 		download \

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,15 @@
 run:
 	cargo run -p sim-validator-assignment -- \
+		run \
 		--num-blocks 1000 \
 		--num-shards 1 \
 		--seats-per-shard 250 \
 		--stake-per-seat 1 \
 		--max-malicious-stake-per-shard 1/2
-		
+
+download:
+	cargo run -p sim-validator-assignment -- \
+		download \
+		--protocol near	\
+		--rpc-url 'https://rpc.testnet.near.org' \
+		--out ./validator_data.json

--- a/dl-validator-data/src/lib.rs
+++ b/dl-validator-data/src/lib.rs
@@ -2,4 +2,4 @@ mod near;
 mod protocol;
 
 pub use near::NearProtocol;
-pub use protocol::Protocol;
+pub use protocol::{Protocol, ValidatorData};

--- a/sim-validator-assignment/Cargo.toml
+++ b/sim-validator-assignment/Cargo.toml
@@ -8,9 +8,11 @@ edition = "2021"
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true
+dl-validator-data = { path = "../dl-validator-data" }
 fastrand.workspace = true
 num-rational.workspace = true
 serde.workspace = true
+serde_json.workspace = true
 
 [dev-dependencies]
 insta.workspace = true

--- a/sim-validator-assignment/src/config.rs
+++ b/sim-validator-assignment/src/config.rs
@@ -1,10 +1,10 @@
-use clap::Parser;
+use clap::Args;
 use num_rational::Ratio;
 use serde::Serialize;
 
 use crate::seat::Seat;
 
-#[derive(Parser, Serialize, Debug)]
+#[derive(Args, Serialize, Debug)]
 pub struct Config {
     #[arg(long)]
     pub num_blocks: u64,

--- a/sim-validator-assignment/src/download.rs
+++ b/sim-validator-assignment/src/download.rs
@@ -1,0 +1,50 @@
+use clap::{Args, ValueEnum};
+use std::fs::File;
+use std::{io::Write, path::PathBuf};
+
+use dl_validator_data::{NearProtocol, Protocol as DlValidatorDataProtocol};
+
+use crate::validator::RawValidatorData;
+
+#[derive(Args, Debug)]
+pub(crate) struct DownloadConfig {
+    /// The protocol for which to download data.
+    #[arg(long, value_enum)]
+    pub protocol: Protocol,
+    /// URL of an RPC from which to download the data.
+    #[arg(long)]
+    pub rpc_url: String,
+    /// Block height for which validator data is downloaded. If no value is provided the latest
+    /// block will be queried.
+    #[arg(long)]
+    pub block_height: Option<u64>,
+    /// The path of the file to which validator data will be written.
+    #[arg(long)]
+    pub out: PathBuf,
+}
+
+#[derive(ValueEnum, Copy, Clone, Debug, PartialEq, Eq)]
+pub(crate) enum Protocol {
+    Near,
+}
+
+/// Downloads validator data, converts it to a vector of [`RawValidatorData`] and writes the
+/// corresponding(pretty printed) JSON to the output file specified in `config`.
+///
+/// Pretty print JSON assuming users might want to inspect and modify validator data (mark
+/// validators as malicious for simulations).
+pub(crate) fn download(config: &DownloadConfig) -> anyhow::Result<()> {
+    // Download validator data.
+    let protocol = match config.protocol {
+        Protocol::Near => NearProtocol::new(config.rpc_url.clone(), config.block_height),
+    };
+    let validator_data = protocol.download_validator_data()?;
+    let validators: Vec<RawValidatorData> = validator_data.into_iter().map(|v| v.into()).collect();
+
+    // Serialize it and write it to the output file.
+    let pretty_json = serde_json::to_string_pretty(&validators)?;
+    let mut file = File::create(config.out.as_path())?;
+    file.write_all(pretty_json.as_bytes())?;
+
+    Ok(())
+}

--- a/sim-validator-assignment/src/main.rs
+++ b/sim-validator-assignment/src/main.rs
@@ -3,64 +3,13 @@ use clap::Parser;
 mod config;
 use config::Config;
 mod mocks;
+mod run;
 mod seat;
-use seat::ShuffledSeats;
 mod shard;
-use shard::Shard;
+use run::run;
 mod validator;
-use validator::{new_ordered_seats, parse_raw_validator_data};
 
 fn main() -> anyhow::Result<()> {
     let config = Config::parse();
-
-    // Mock a set of validators corresponding to the one used in Table 4 of this paper
-    // https://www.montrealblockchainlab.com/New%20Mathematical%20Model.pdf
-    // We model 1/3 of validators as malicious which corresponds to Class B (see Table 1).
-    let num_validators = 4000;
-    let raw_validator_data = mocks::new_validators(num_validators, 1, num_validators / 3);
-
-    let (population_stats, validators) = parse_raw_validator_data(&config, &raw_validator_data);
-
-    println!("population_stats: {:?}", population_stats);
-    if population_stats.seats < u64::from(config.num_shards) * config.seats_per_shard {
-        anyhow::bail!(
-            "Validators cover {} seats, config requires {} seats",
-            population_stats.seats,
-            config.total_seats()
-        )
-    }
-
-    let mut num_corrupted_shards = 0;
-
-    for block_height in 0..config.num_blocks {
-        let mut ordered_seats = new_ordered_seats(&validators);
-        let shuffled_seats = ShuffledSeats::new(&mut ordered_seats);
-
-        for shard_idx in 0..config.num_shards {
-            let shard_idx = usize::from(shard_idx);
-            let shard_seats =
-                config.collect_seats_for_shard(shard_idx, shuffled_seats.get_seats())?;
-            let shard = Shard::new(&config, shard_seats)?;
-            if shard.is_corrupted(&config) {
-                num_corrupted_shards += 1;
-            }
-        }
-
-        if block_height % 100_000 == 0 {
-            log_heartbeat(
-                block_height,
-                block_height * u64::from(config.num_shards),
-                num_corrupted_shards,
-            );
-        }
-    }
-
-    println!("Simulated {} blocks with {} shards each. The number of corrupted shards out of total shards is {} / {}",
-    config.num_blocks, config.num_shards, num_corrupted_shards, config.num_blocks * u64::from(config.num_shards)
-);
-    Ok(())
-}
-
-fn log_heartbeat(block_height: u64, num_simulated_shards: u64, num_corrupted_shards: u64) {
-    println!("heartbeat(block_height: {block_height}): {num_corrupted_shards} / {num_simulated_shards} shards corrupted");
+    run(&config)
 }

--- a/sim-validator-assignment/src/main.rs
+++ b/sim-validator-assignment/src/main.rs
@@ -1,7 +1,9 @@
-use clap::Parser;
+use clap::{Parser, Subcommand};
 
 mod config;
 use config::Config;
+mod download;
+use download::{download, DownloadConfig};
 mod mocks;
 mod run;
 mod seat;
@@ -9,7 +11,28 @@ mod shard;
 use run::run;
 mod validator;
 
+/// A CLI to simulate blockchain validator assignments.
+#[derive(Parser, Debug)]
+#[command(name = "sim-validator-assignment")]
+#[command(about = "A CLI to simulate blockchain validator assignments", long_about = None)]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, Subcommand)]
+enum Command {
+    /// Runs a simulation
+    #[command(arg_required_else_help = true)]
+    Run(Config),
+    /// Downloads valdiator data
+    Download(DownloadConfig),
+}
+
 fn main() -> anyhow::Result<()> {
-    let config = Config::parse();
-    run(&config)
+    let args = Cli::parse();
+    match args.command {
+        Command::Run(config) => run(&config),
+        Command::Download(dl_config) => download(&dl_config),
+    }
 }

--- a/sim-validator-assignment/src/run.rs
+++ b/sim-validator-assignment/src/run.rs
@@ -1,0 +1,58 @@
+use crate::config::Config;
+use crate::seat::ShuffledSeats;
+use crate::shard::Shard;
+use crate::validator::{new_ordered_seats, parse_raw_validator_data};
+
+pub fn run(config: &Config) -> anyhow::Result<()> {
+    // Mock a set of validators corresponding to the one used in Table 4 of this paper
+    // https://www.montrealblockchainlab.com/New%20Mathematical%20Model.pdf
+    // We model 1/3 of validators as malicious which corresponds to Class B (see Table 1).
+    let num_validators = 4000;
+    let raw_validator_data = crate::mocks::new_validators(num_validators, 1, num_validators / 3);
+
+    let (population_stats, validators) = parse_raw_validator_data(&config, &raw_validator_data);
+
+    println!("population_stats: {:?}", population_stats);
+    if population_stats.seats < u64::from(config.num_shards) * config.seats_per_shard {
+        anyhow::bail!(
+            "Validators cover {} seats, config requires {} seats",
+            population_stats.seats,
+            config.total_seats()
+        )
+    }
+
+    let mut num_corrupted_shards = 0;
+
+    for block_height in 0..config.num_blocks {
+        let mut ordered_seats = new_ordered_seats(&validators);
+        let shuffled_seats = ShuffledSeats::new(&mut ordered_seats);
+
+        for shard_idx in 0..config.num_shards {
+            let shard_idx = usize::from(shard_idx);
+            let shard_seats =
+                config.collect_seats_for_shard(shard_idx, shuffled_seats.get_seats())?;
+            let shard = Shard::new(&config, shard_seats)?;
+            if shard.is_corrupted(&config) {
+                num_corrupted_shards += 1;
+            }
+        }
+
+        if block_height % 100_000 == 0 {
+            log_heartbeat(
+                block_height,
+                block_height * u64::from(config.num_shards),
+                num_corrupted_shards,
+            );
+        }
+    }
+
+    println!(
+        "Simulated {} blocks with {} shards each. The number of corrupted shards out of total shards is {} / {}",
+        config.num_blocks, config.num_shards, num_corrupted_shards, config.num_blocks * u64::from(config.num_shards)
+    );
+    Ok(())
+}
+
+fn log_heartbeat(block_height: u64, num_simulated_shards: u64, num_corrupted_shards: u64) {
+    println!("heartbeat(block_height: {block_height}): {num_corrupted_shards} / {num_simulated_shards} shards corrupted");
+}

--- a/sim-validator-assignment/src/validator.rs
+++ b/sim-validator-assignment/src/validator.rs
@@ -39,6 +39,18 @@ pub fn parse_raw_validator_data(
     (population_stats, validators)
 }
 
+impl From<dl_validator_data::ValidatorData> for RawValidatorData {
+    /// The returned validator is malicious if `data.is_malicious == Some(true)`, otherwise it is
+    /// not malicious.
+    fn from(data: dl_validator_data::ValidatorData) -> Self {
+        Self {
+            account_id: data.account_id,
+            stake: data.stake,
+            is_malicious: data.is_malicious.is_some_and(|is_malicious| is_malicious),
+        }
+    }
+}
+
 /// Holds data describing a set of validators.
 #[derive(Serialize, Default, Debug)]
 pub struct PopulationStats {


### PR DESCRIPTION
- Adds support for CLI subcommands. Previously, running a simulation was the only command. Now, this functionality is available under the `run` subcommand.
- Adds the `download` subcommand which downloads validator data from an RPC and writes it to a JSON file. This uses the workspace’s `dl-validator-data` crate under the hood.

Targets in the `Makefile` have been updated and show examples of invoking all available subcommands.