### PR TITLE
feat: enable `run` to read validator data from file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,5 +13,20 @@ download:
 	cargo run -p sim-validator-assignment -- \
 		download \
 		--protocol near	\
-		--rpc-url 'https://rpc.testnet.near.org' \
+		--rpc-url 'https://archival-rpc.testnet.near.org' \
+		--block-height 140053158 \
 		--out ./validator_data.json
+
+# Runs a simulation reading data from `./validator_data.json` which is assumed to be obtained by
+# invoking the `download` target defined above.
+.PHONY: run-with
+run-with:
+	cargo run -p sim-validator-assignment -- \
+		run \
+		--num-blocks 1000 \
+		--num-shards 4 \
+		--seats-per-shard 250 \
+		--stake-per-seat 50000000000000000000000000000 \
+		--max-malicious-stake-per-shard 2/3 \
+		--validator-data ./validator_data.json
+

--- a/sim-validator-assignment/src/config.rs
+++ b/sim-validator-assignment/src/config.rs
@@ -1,6 +1,7 @@
 use clap::Args;
 use num_rational::Ratio;
 use serde::Serialize;
+use std::path::PathBuf;
 
 use crate::seat::Seat;
 
@@ -24,6 +25,11 @@ pub struct Config {
     /// corrupted, i.e. a security failure occured.
     #[arg(long)]
     pub max_malicious_stake_per_shard: Ratio<u128>,
+    /// The file from which validator data is read. It is expected to contain a vector of
+    /// `RawValidatorData` serialized as JSON. If no validator data is provided, mocked validator
+    /// data will be used in the simulation.
+    #[arg(long)]
+    pub validator_data: Option<PathBuf>,
 }
 
 impl Config {
@@ -35,6 +41,7 @@ impl Config {
             seats_per_shard: 2,
             stake_per_seat: 100,
             max_malicious_stake_per_shard: Ratio::new(1, 3),
+            validator_data: None,
         }
     }
 

--- a/sim-validator-assignment/src/validator.rs
+++ b/sim-validator-assignment/src/validator.rs
@@ -1,10 +1,10 @@
 use num_rational::Ratio;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::config::Config;
 use crate::seat::Seat;
 
-#[derive(Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug)]
 pub struct RawValidatorData {
     pub account_id: String,
     pub stake: u128,


### PR DESCRIPTION
Providing a file that contains validator data is optional. Without `--validator-data` command `run` will use a mocked validator set, which corresponds to the behavior prior to this PR.

Target `run-with` in the `Makefile` provides an example of using `--validator-data`.