### PR TITLE
feat: collect and print more stats

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ clap = { version = "4.4.2", features = ["derive"] }
 fastrand = "2.0"
 insta = { version = "1.31.0", features = ["yaml"] }
 num-rational = {version="0.4", features = ["serde"]}
+num-traits = "0.2"
 reqwest = { version = "0.11", features = ["blocking", "json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/sim-validator-assignment/Cargo.toml
+++ b/sim-validator-assignment/Cargo.toml
@@ -11,6 +11,7 @@ clap.workspace = true
 dl-validator-data = { path = "../dl-validator-data" }
 fastrand.workspace = true
 num-rational.workspace = true
+num-traits.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 

--- a/sim-validator-assignment/src/run.rs
+++ b/sim-validator-assignment/src/run.rs
@@ -2,6 +2,8 @@ use crate::config::Config;
 use crate::seat::ShuffledSeats;
 use crate::shard::Shard;
 use crate::validator::{new_ordered_seats, parse_raw_validator_data, RawValidatorData};
+use num_rational::Ratio;
+use num_traits::ToPrimitive;
 use std::fs::read_to_string;
 use std::path::Path;
 
@@ -14,6 +16,19 @@ pub fn run(config: &Config) -> anyhow::Result<()> {
     let (population_stats, validators) = parse_raw_validator_data(&config, &raw_validator_data);
 
     println!("population_stats: {:?}", population_stats);
+    println!(
+        "malicious_stake / stake ≈ {:.5}",
+        Ratio::new(population_stats.malicious_stake, population_stats.stake)
+            .to_f64()
+            .unwrap()
+    );
+    println!(
+        "malicious_seats / seats ≈ {:.5}",
+        Ratio::new(population_stats.malicious_seats, population_stats.seats)
+            .to_f64()
+            .unwrap()
+    );
+
     if population_stats.seats < u64::from(config.num_shards) * config.seats_per_shard {
         anyhow::bail!(
             "Validators cover {} seats, config requires {} seats",

--- a/sim-validator-assignment/src/snapshots/sim_validator_assignment__validator__tests__parse_raw_validator_input.snap
+++ b/sim-validator-assignment/src/snapshots/sim_validator_assignment__validator__tests__parse_raw_validator_input.snap
@@ -1,5 +1,5 @@
 ---
-source: src/validator.rs
+source: sim-validator-assignment/src/validator.rs
 expression: population_stats
 info:
   num_blocks: 1000
@@ -9,8 +9,10 @@ info:
   max_malicious_stake_per_shard:
     - 1
     - 3
+  validator_data: ~
 ---
 stake: 1800
 malicious_stake: 410
 seats: 17
+malicious_seats: 4
 

--- a/sim-validator-assignment/src/validator.rs
+++ b/sim-validator-assignment/src/validator.rs
@@ -61,8 +61,8 @@ pub struct PopulationStats {
     /// Sum of stake of malicious validator stakes.
     pub malicious_stake: u128,
     /// Total number of seats of all validators. Note that some stake might not participate in
-    /// validation if it is not assigned to a seat. For example, if a validator has stake 17 and
-    /// seat price is 5, then the validator holds 3 seats (worth 15 stake) and 2 stake remain
+    /// validation if it is not assigned to a seat. For example, if a validator has a stake of 17
+    /// and seat price is 5, then the validator holds 3 seats (worth 15 stake) and 2 stake remain
     /// unassigned.
     pub seats: u64,
     /// The number of seats held by malicious validators.
@@ -144,7 +144,7 @@ pub mod tests {
                 stake: 90,
                 is_malicious: false,
             },
-            // Some more validators enough for running tests.
+            // Some more validators, to have enough for running tests.
             RawValidatorData {
                 account_id: "validator_3".to_owned(),
                 stake: 100,

--- a/sim-validator-assignment/src/validator.rs
+++ b/sim-validator-assignment/src/validator.rs
@@ -20,10 +20,12 @@ pub fn parse_raw_validator_data(
 
     for v in input.iter() {
         population_stats.stake += v.stake;
+        let num_seats = config.seats_per_stake(v.stake);
+        population_stats.seats += num_seats;
         if v.is_malicious {
             population_stats.malicious_stake += v.stake;
+            population_stats.malicious_seats += num_seats;
         }
-        population_stats.seats += config.seats_per_stake(v.stake);
     }
 
     for v in input.iter() {
@@ -58,8 +60,13 @@ pub struct PopulationStats {
     pub stake: u128,
     /// Sum of stake of malicious validator stakes.
     pub malicious_stake: u128,
-    /// Total number of seats of all validators.
+    /// Total number of seats of all validators. Note that some stake might not participate in
+    /// validation if it is not assigned to a seat. For example, if a validator has stake 17 and
+    /// seat price is 5, then the validator holds 3 seats (worth 15 stake) and 2 stake remain
+    /// unassigned.
     pub seats: u64,
+    /// The number of seats held by malicious validators.
+    pub malicious_seats: u64,
 }
 
 #[derive(Serialize, PartialEq, Debug)]


### PR DESCRIPTION
- Adds field `malicious_seats` to `PopulationStats`.
- Prints the fractions of malicous stake and seats.

Dependency `num-traits` is added to call `to_f64` on a `Ratio`.