### PR TITLE
feat: add support for --include-partial-seats

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,11 @@ run:
 	cargo run -p sim-validator-assignment -- \
 		run \
 		--num-blocks 1000 \
-		--num-shards 1 \
+		--num-shards 4 \
 		--seats-per-shard 250 \
 		--stake-per-seat 1 \
-		--max-malicious-stake-per-shard 1/2
+		--max-malicious-stake-per-shard 1/2 \
+		--include-partial-seats
 
 .PHONY: download
 download:
@@ -28,5 +29,6 @@ run-with:
 		--seats-per-shard 250 \
 		--stake-per-seat 50000000000000000000000000000 \
 		--max-malicious-stake-per-shard 2/3 \
+		--include-partial-seats \
 		--validator-data ./validator_data.json
 

--- a/sim-validator-assignment/src/config.rs
+++ b/sim-validator-assignment/src/config.rs
@@ -3,7 +3,7 @@ use num_rational::Ratio;
 use serde::Serialize;
 use std::path::PathBuf;
 
-use crate::seat::Seat;
+use crate::{partial_seat::PartialSeat, seat::Seat};
 
 #[derive(Args, Serialize, Debug)]
 pub struct Config {
@@ -30,11 +30,16 @@ pub struct Config {
     /// data will be used in the simulation.
     #[arg(long)]
     pub validator_data: Option<PathBuf>,
+    /// A validator's stake might not entirely cover seats given a particular `stake_per_seat`. This
+    /// option controls whether remaining stake (not covering a full seat) should be assigned to a
+    /// partial seat or ignored.
+    #[arg(long, default_value_t = false)]
+    pub include_partial_seats: bool,
 }
 
 impl Config {
     #[cfg(test)]
-    pub fn new_mock() -> Self {
+    pub fn new_mock(include_partial_seats: bool) -> Self {
         Self {
             num_blocks: 1_000,
             num_shards: 4,
@@ -42,6 +47,7 @@ impl Config {
             stake_per_seat: 100,
             max_malicious_stake_per_shard: Ratio::new(1, 3),
             validator_data: None,
+            include_partial_seats,
         }
     }
 
@@ -93,31 +99,70 @@ impl Config {
 
         Ok(shard_seats)
     }
+
+    /// Collect partials seats for `shard_idx` by picking seats from positions with `position %
+    /// num_shards == shard_idx`.
+    ///
+    /// # Motivation for assignment via modulo
+    ///
+    /// Every validator may hold at most 1 partial seat. If a validator's stake covers full seats
+    /// without remainder, it holds 0 partial seats. Hence `0 <= num_partial_seats <=
+    /// num_validators`. Assigning seats to shards with `%` allows distributing the existing number
+    /// of partial seats to shards as evenly as possible.
+    ///
+    /// # No minimum number of required _partial_ seats per shard
+    ///
+    /// It is not needed since partial seats are included only to distribute leftover stake (not
+    /// covering full seats) to shards.
+    pub fn collect_partial_seats_for_shard<'seats>(
+        &self,
+        shard_idx: usize,
+        partial_seats: &'seats [PartialSeat],
+    ) -> anyhow::Result<Vec<&PartialSeat<'seats>>> {
+        if shard_idx >= usize::from(self.num_shards) {
+            anyhow::bail!(
+                "shard_idx {} is an invalid index for {} shards",
+                shard_idx,
+                self.num_shards
+            )
+        }
+
+        let mut shard_partial_seats = vec![];
+        for idx in (shard_idx..partial_seats.len()).step_by(self.num_shards.into()) {
+            shard_partial_seats.push(&partial_seats[idx]);
+        }
+
+        Ok(shard_partial_seats)
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use super::Config;
     use crate::validator::tests::new_test_raw_validator_data;
-    use crate::validator::{new_ordered_seats, parse_raw_validator_data};
+    use crate::validator::{
+        new_ordered_partial_seats, new_ordered_seats, parse_raw_validator_data,
+    };
 
     #[test]
-    pub fn test_seats_per_stake() {
-        let config = Config::new_mock();
+    fn test_seats_per_stake() {
+        let config = Config::new_mock(false);
         assert_eq!(config.seats_per_stake(20), 0);
         assert_eq!(config.seats_per_stake(100), 1);
         assert_eq!(config.seats_per_stake(530), 5);
     }
 
     #[test]
-    pub fn test_total_seats() {
-        let config = Config::new_mock();
+    fn test_total_seats() {
+        let config = Config::new_mock(false);
         assert_eq!(config.total_seats(), 8);
     }
 
     #[test]
-    pub fn test_collect_seats_for_shard() {
-        let config = Config::new_mock();
+    fn test_collect_seats_for_shard() {
+        let config = Config::new_mock(false);
         let (_, validators) = parse_raw_validator_data(&config, &new_test_raw_validator_data());
         // Using ordered seats as input to have a deterministic result of `collect_seats_for_shard`.
         let seats = new_ordered_seats(&validators);
@@ -137,12 +182,52 @@ mod tests {
     }
 
     #[test]
-    pub fn test_collect_seats_for_shard_errors() {
-        let config = Config::new_mock();
+    fn test_collect_seats_for_shard_errors() {
+        let config = Config::new_mock(false);
         let (_, validators) = parse_raw_validator_data(&config, &new_test_raw_validator_data());
         let seats = new_ordered_seats(&validators);
 
         insta::assert_debug_snapshot!(config.collect_seats_for_shard(4, &seats));
         insta::assert_debug_snapshot!(config.collect_seats_for_shard(0, &[]));
+    }
+
+    #[test]
+    fn test_collect_partial_seats_for_shard() {
+        let mut config = Config::new_mock(true);
+        config.stake_per_seat = 90;
+        let (_, validators) = parse_raw_validator_data(&config, &new_test_raw_validator_data());
+        // Using ordered partial seats as input to have a deterministic result of
+        // `collect_partial_seats_for_shard`.
+        let partial_seats = new_ordered_partial_seats(&validators, config.stake_per_seat);
+
+        // Using `BTreeMap` for deterministic ordering of keys.
+        let mut assignments = BTreeMap::new();
+        for shard_idx in 0..config.num_shards {
+            let assignment = config
+                .collect_partial_seats_for_shard(shard_idx.into(), &partial_seats)
+                .unwrap();
+            assignments.insert(format!("shard_{shard_idx}"), assignment);
+        }
+
+        insta::with_settings!({
+            info => &(
+                &config,
+                "partial_seats:",
+                &partial_seats
+            )
+        }, {
+            insta::assert_yaml_snapshot!(assignments);
+        })
+    }
+
+    #[test]
+    fn test_collect_partial_seats_for_shard_errors() {
+        let config = Config::new_mock(true);
+        let (_, validators) = parse_raw_validator_data(&config, &new_test_raw_validator_data());
+        let partial_seats = new_ordered_partial_seats(&validators, config.stake_per_seat);
+
+        insta::assert_debug_snapshot!(
+            config.collect_partial_seats_for_shard(config.num_shards.into(), &partial_seats)
+        );
     }
 }

--- a/sim-validator-assignment/src/main.rs
+++ b/sim-validator-assignment/src/main.rs
@@ -5,6 +5,7 @@ use config::Config;
 mod download;
 use download::{download, DownloadConfig};
 mod mocks;
+mod partial_seat;
 mod run;
 mod seat;
 mod shard;

--- a/sim-validator-assignment/src/partial_seat.rs
+++ b/sim-validator-assignment/src/partial_seat.rs
@@ -36,7 +36,7 @@ pub struct ShuffledPartialSeats<'seats> {
 }
 
 impl<'seats> ShuffledPartialSeats<'seats> {
-    /// Shuffled the input `partial_seats`.
+    /// Shuffles the input `partial_seats`.
     // TODO(rand) do all shuffling operations in one generic fn
     pub fn new(partial_seats: &'seats mut [PartialSeat<'seats>]) -> Self {
         fastrand::shuffle(partial_seats);

--- a/sim-validator-assignment/src/partial_seat.rs
+++ b/sim-validator-assignment/src/partial_seat.rs
@@ -1,0 +1,49 @@
+use serde::Serialize;
+
+use crate::validator::Validator;
+
+/// Represents a partial seat filled by a particular validator.
+///
+/// A partial seat may not outlive the validator it is referrencing.
+#[derive(Serialize, PartialEq, Debug, Clone)]
+pub struct PartialSeat<'validator> {
+    /// Reference to the validator holding this particular partial seat.
+    validator: &'validator Validator,
+    /// The stake attributed to the partial seat. Note that `0 < weight < stake_per_seat`.
+    ///
+    /// For example, let validator `V` have a stake of 12 and let `stake_per_seat = 5`. Then `V`
+    /// holds 2 full seats and a partial seat with `weight = 2`.
+    weight: u128,
+}
+
+impl<'validator> PartialSeat<'validator> {
+    /// Constructs the partial seat filled by `validator`.
+    pub fn new(validator: &'validator Validator, weight: u128) -> Self {
+        Self { validator, weight }
+    }
+
+    pub fn get_is_malicious(&self) -> bool {
+        self.validator.get_is_malicious()
+    }
+
+    pub fn get_weight(&self) -> u128 {
+        self.weight
+    }
+}
+
+pub struct ShuffledPartialSeats<'seats> {
+    partial_seats: &'seats [PartialSeat<'seats>],
+}
+
+impl<'seats> ShuffledPartialSeats<'seats> {
+    /// Shuffled the input `partial_seats`.
+    // TODO(rand) do all shuffling operations in one generic fn
+    pub fn new(partial_seats: &'seats mut [PartialSeat<'seats>]) -> Self {
+        fastrand::shuffle(partial_seats);
+        Self { partial_seats }
+    }
+
+    pub fn get_partial_seats(&self) -> &[PartialSeat] {
+        self.partial_seats
+    }
+}

--- a/sim-validator-assignment/src/run.rs
+++ b/sim-validator-assignment/src/run.rs
@@ -1,7 +1,10 @@
 use crate::config::Config;
+use crate::partial_seat::{PartialSeat, ShuffledPartialSeats};
 use crate::seat::ShuffledSeats;
 use crate::shard::Shard;
-use crate::validator::{new_ordered_seats, parse_raw_validator_data, RawValidatorData};
+use crate::validator::{
+    new_ordered_partial_seats, new_ordered_seats, parse_raw_validator_data, RawValidatorData,
+};
 use num_rational::Ratio;
 use num_traits::ToPrimitive;
 use std::fs::read_to_string;
@@ -13,7 +16,7 @@ pub fn run(config: &Config) -> anyhow::Result<()> {
         None => mock_validator_data(),
     };
 
-    let (population_stats, validators) = parse_raw_validator_data(&config, &raw_validator_data);
+    let (population_stats, validators) = parse_raw_validator_data(config, &raw_validator_data);
 
     println!("population_stats: {:?}", population_stats);
     println!(
@@ -40,15 +43,24 @@ pub fn run(config: &Config) -> anyhow::Result<()> {
     let mut num_corrupted_shards = 0;
 
     for block_height in 0..config.num_blocks {
-        let mut ordered_seats = new_ordered_seats(&validators);
-        let shuffled_seats = ShuffledSeats::new(&mut ordered_seats);
+        let mut seats = new_ordered_seats(&validators);
+        let shuffled_seats = ShuffledSeats::new(&mut seats);
+
+        let mut partial_seats = config
+            .include_partial_seats
+            .then(|| new_ordered_partial_seats(&validators, config.stake_per_seat));
+        let shuffled_partial_seats = partial_seats
+            .as_mut()
+            .map(|ps| ShuffledPartialSeats::new(ps));
 
         for shard_idx in 0..config.num_shards {
             let shard_idx = usize::from(shard_idx);
             let shard_seats =
                 config.collect_seats_for_shard(shard_idx, shuffled_seats.get_seats())?;
-            let shard = Shard::new(&config, shard_seats)?;
-            if shard.is_corrupted(&config) {
+            let shard_partial_seats =
+                get_partial_seats_for_shard(config, shuffled_partial_seats.as_ref(), shard_idx)?;
+            let shard = Shard::new(config, shard_seats, shard_partial_seats)?;
+            if shard.is_corrupted(config) {
                 num_corrupted_shards += 1;
             }
         }
@@ -86,4 +98,19 @@ fn mock_validator_data() -> Vec<RawValidatorData> {
 
 fn log_heartbeat(block_height: u64, num_simulated_shards: u64, num_corrupted_shards: u64) {
     println!("heartbeat(block_height: {block_height}): {num_corrupted_shards} / {num_simulated_shards} shards corrupted");
+}
+
+fn get_partial_seats_for_shard<'a>(
+    config: &'a Config,
+    partial_seats: Option<&'a ShuffledPartialSeats>,
+    shard_idx: usize,
+) -> anyhow::Result<Option<Vec<&'a PartialSeat<'a>>>> {
+    match partial_seats {
+        Some(partial_seats) => {
+            let shard_seats = config
+                .collect_partial_seats_for_shard(shard_idx, partial_seats.get_partial_seats())?;
+            Ok(Some(shard_seats))
+        }
+        None => Ok(None),
+    }
 }

--- a/sim-validator-assignment/src/seat.rs
+++ b/sim-validator-assignment/src/seat.rs
@@ -28,12 +28,13 @@ pub struct ShuffledSeats<'seats> {
 
 impl<'seats> ShuffledSeats<'seats> {
     /// Shuffles the input `seats`.
+    // TODO(rand) do all shuffling operations in one generic fn
     pub fn new(seats: &'seats mut [Seat<'seats>]) -> Self {
         fastrand::shuffle(seats);
         Self { seats }
     }
 
     pub fn get_seats(&self) -> &[Seat] {
-        &self.seats
+        self.seats
     }
 }

--- a/sim-validator-assignment/src/shard.rs
+++ b/sim-validator-assignment/src/shard.rs
@@ -6,8 +6,7 @@ use num_rational::Ratio;
 #[derive(Debug, Default)]
 pub struct Shard<'seats> {
     seats: Vec<&'seats Seat<'seats>>,
-    /// Contains partial seats in case they are enabled by configuration.
-    partial_seats: Option<Vec<&'seats PartialSeat<'seats>>>,
+    partial_seats: Vec<&'seats PartialSeat<'seats>>,
     stake: u128,
     malicious_stake: u128,
 }
@@ -16,7 +15,7 @@ impl<'seats> Shard<'seats> {
     pub fn new(
         config: &Config,
         seats: Vec<&'seats Seat>,
-        partial_seats: Option<Vec<&'seats PartialSeat>>,
+        partial_seats: Vec<&'seats PartialSeat>,
     ) -> anyhow::Result<Self> {
         if seats.len() != usize::try_from(config.seats_per_shard).unwrap() {
             // Count only _full_ seats for the minimum number of required seats, since it is not
@@ -38,13 +37,11 @@ impl<'seats> Shard<'seats> {
             }
         }
 
-        if let Some(partial_seats) = partial_seats.as_ref() {
-            for &ps in partial_seats.iter() {
-                let weight = ps.get_weight();
-                shard.stake += weight;
-                if ps.get_is_malicious() {
-                    shard.malicious_stake += weight;
-                }
+        for ps in partial_seats.iter() {
+            let weight = ps.get_weight();
+            shard.stake += weight;
+            if ps.get_is_malicious() {
+                shard.malicious_stake += weight;
             }
         }
 

--- a/sim-validator-assignment/src/snapshots/sim_validator_assignment__config__tests__collect_partial_seats_for_shard.snap
+++ b/sim-validator-assignment/src/snapshots/sim_validator_assignment__config__tests__collect_partial_seats_for_shard.snap
@@ -1,0 +1,218 @@
+---
+source: sim-validator-assignment/src/config.rs
+expression: assignments
+info:
+  - num_blocks: 1000
+    num_shards: 4
+    seats_per_shard: 2
+    stake_per_seat: 90
+    max_malicious_stake_per_shard:
+      - 1
+      - 3
+    validator_data: ~
+    include_partial_seats: false
+  - "partial_seats:"
+  - - validator:
+        account_id: validator_0
+        stake: 500
+        is_malicious: false
+        num_seats: 5
+        total_stake_share:
+          - 5
+          - 18
+      weight: 50
+    - validator:
+        account_id: validator_1
+        stake: 310
+        is_malicious: true
+        num_seats: 3
+        total_stake_share:
+          - 31
+          - 180
+      weight: 40
+    - validator:
+        account_id: validator_3
+        stake: 100
+        is_malicious: true
+        num_seats: 1
+        total_stake_share:
+          - 1
+          - 18
+      weight: 10
+    - validator:
+        account_id: validator_4
+        stake: 100
+        is_malicious: false
+        num_seats: 1
+        total_stake_share:
+          - 1
+          - 18
+      weight: 10
+    - validator:
+        account_id: validator_5
+        stake: 100
+        is_malicious: false
+        num_seats: 1
+        total_stake_share:
+          - 1
+          - 18
+      weight: 10
+    - validator:
+        account_id: validator_6
+        stake: 100
+        is_malicious: false
+        num_seats: 1
+        total_stake_share:
+          - 1
+          - 18
+      weight: 10
+    - validator:
+        account_id: validator_7
+        stake: 100
+        is_malicious: false
+        num_seats: 1
+        total_stake_share:
+          - 1
+          - 18
+      weight: 10
+    - validator:
+        account_id: validator_8
+        stake: 100
+        is_malicious: false
+        num_seats: 1
+        total_stake_share:
+          - 1
+          - 18
+      weight: 10
+    - validator:
+        account_id: validator_9
+        stake: 100
+        is_malicious: false
+        num_seats: 1
+        total_stake_share:
+          - 1
+          - 18
+      weight: 10
+    - validator:
+        account_id: validator_10
+        stake: 100
+        is_malicious: false
+        num_seats: 1
+        total_stake_share:
+          - 1
+          - 18
+      weight: 10
+    - validator:
+        account_id: validator_11
+        stake: 100
+        is_malicious: false
+        num_seats: 1
+        total_stake_share:
+          - 1
+          - 18
+      weight: 10
+---
+shard_0:
+  - validator:
+      account_id: validator_0
+      stake: 500
+      is_malicious: false
+      num_seats: 5
+      total_stake_share:
+        - 5
+        - 18
+    weight: 50
+  - validator:
+      account_id: validator_5
+      stake: 100
+      is_malicious: false
+      num_seats: 1
+      total_stake_share:
+        - 1
+        - 18
+    weight: 10
+  - validator:
+      account_id: validator_9
+      stake: 100
+      is_malicious: false
+      num_seats: 1
+      total_stake_share:
+        - 1
+        - 18
+    weight: 10
+shard_1:
+  - validator:
+      account_id: validator_1
+      stake: 310
+      is_malicious: true
+      num_seats: 3
+      total_stake_share:
+        - 31
+        - 180
+    weight: 40
+  - validator:
+      account_id: validator_6
+      stake: 100
+      is_malicious: false
+      num_seats: 1
+      total_stake_share:
+        - 1
+        - 18
+    weight: 10
+  - validator:
+      account_id: validator_10
+      stake: 100
+      is_malicious: false
+      num_seats: 1
+      total_stake_share:
+        - 1
+        - 18
+    weight: 10
+shard_2:
+  - validator:
+      account_id: validator_3
+      stake: 100
+      is_malicious: true
+      num_seats: 1
+      total_stake_share:
+        - 1
+        - 18
+    weight: 10
+  - validator:
+      account_id: validator_7
+      stake: 100
+      is_malicious: false
+      num_seats: 1
+      total_stake_share:
+        - 1
+        - 18
+    weight: 10
+  - validator:
+      account_id: validator_11
+      stake: 100
+      is_malicious: false
+      num_seats: 1
+      total_stake_share:
+        - 1
+        - 18
+    weight: 10
+shard_3:
+  - validator:
+      account_id: validator_4
+      stake: 100
+      is_malicious: false
+      num_seats: 1
+      total_stake_share:
+        - 1
+        - 18
+    weight: 10
+  - validator:
+      account_id: validator_8
+      stake: 100
+      is_malicious: false
+      num_seats: 1
+      total_stake_share:
+        - 1
+        - 18
+    weight: 10
+

--- a/sim-validator-assignment/src/snapshots/sim_validator_assignment__config__tests__collect_partial_seats_for_shard_errors.snap
+++ b/sim-validator-assignment/src/snapshots/sim_validator_assignment__config__tests__collect_partial_seats_for_shard_errors.snap
@@ -1,0 +1,7 @@
+---
+source: sim-validator-assignment/src/config.rs
+expression: "config.collect_partial_seats_for_shard(config.num_shards.into(),\n    &partial_seats)"
+---
+Err(
+    "shard_idx 4 is an invalid index for 4 shards",
+)

--- a/sim-validator-assignment/src/snapshots/sim_validator_assignment__validator__tests__new_ordered_partial_seats.snap
+++ b/sim-validator-assignment/src/snapshots/sim_validator_assignment__validator__tests__new_ordered_partial_seats.snap
@@ -1,0 +1,118 @@
+---
+source: sim-validator-assignment/src/validator.rs
+expression: "new_ordered_partial_seats(&validators, config.stake_per_seat)"
+info:
+  - num_blocks: 1000
+    num_shards: 4
+    seats_per_shard: 2
+    stake_per_seat: 100
+    max_malicious_stake_per_shard:
+      - 1
+      - 3
+    validator_data: ~
+    include_partial_seats: false
+  - "validators:"
+  - - account_id: validator_0
+      stake: 500
+      is_malicious: false
+      num_seats: 5
+      total_stake_share:
+        - 5
+        - 18
+    - account_id: validator_1
+      stake: 310
+      is_malicious: true
+      num_seats: 3
+      total_stake_share:
+        - 31
+        - 180
+    - account_id: validator_2
+      stake: 90
+      is_malicious: false
+      num_seats: 0
+      total_stake_share:
+        - 1
+        - 20
+    - account_id: validator_3
+      stake: 100
+      is_malicious: true
+      num_seats: 1
+      total_stake_share:
+        - 1
+        - 18
+    - account_id: validator_4
+      stake: 100
+      is_malicious: false
+      num_seats: 1
+      total_stake_share:
+        - 1
+        - 18
+    - account_id: validator_5
+      stake: 100
+      is_malicious: false
+      num_seats: 1
+      total_stake_share:
+        - 1
+        - 18
+    - account_id: validator_6
+      stake: 100
+      is_malicious: false
+      num_seats: 1
+      total_stake_share:
+        - 1
+        - 18
+    - account_id: validator_7
+      stake: 100
+      is_malicious: false
+      num_seats: 1
+      total_stake_share:
+        - 1
+        - 18
+    - account_id: validator_8
+      stake: 100
+      is_malicious: false
+      num_seats: 1
+      total_stake_share:
+        - 1
+        - 18
+    - account_id: validator_9
+      stake: 100
+      is_malicious: false
+      num_seats: 1
+      total_stake_share:
+        - 1
+        - 18
+    - account_id: validator_10
+      stake: 100
+      is_malicious: false
+      num_seats: 1
+      total_stake_share:
+        - 1
+        - 18
+    - account_id: validator_11
+      stake: 100
+      is_malicious: false
+      num_seats: 1
+      total_stake_share:
+        - 1
+        - 18
+---
+- validator:
+    account_id: validator_1
+    stake: 310
+    is_malicious: true
+    num_seats: 3
+    total_stake_share:
+      - 31
+      - 180
+  weight: 10
+- validator:
+    account_id: validator_2
+    stake: 90
+    is_malicious: false
+    num_seats: 0
+    total_stake_share:
+      - 1
+      - 20
+  weight: 90
+


### PR DESCRIPTION
Adds support for the option `--include-partial-seats`. If enabled, stake that does not cover a full seat is assigned a partial seat.

Motivation:

- Validators with less stake than required for a full seat should participate in validation as well.
- The entire stake of a validator should be committed to validation. This is not the case if partial seats are ignored.

Behavior of the simulation without `--include-partial-seats` remains the same as previously.