### PR TITLE
feat: add `seat-stats` subcommand

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,3 +32,12 @@ run-with:
 		--include-partial-seats \
 		--validator-data ./validator_data.json
 
+# Runs a simulation reading data from `./validator_data.json` which is assumed to be obtained by
+# invoking the `download` target defined above.
+.PHONY: seat-stats
+seat-stats:
+	cargo run -p sim-validator-assignment -- \
+		seat-stats \
+		--validator-data ./validator_data.json \
+		--stake-per-seat 500000000000000000000000000000 \
+		--include-partial-seats

--- a/README.md
+++ b/README.md
@@ -32,6 +32,18 @@ Validator assignment is based on a random shuffle of validator seats. The number
 
 For now, this crate uses [`fastrand`] to shuffle the vector of seats. For the future, it is possible to allow users to chose between different crates that provide randomness. For instance with feature flags at compile time or with CLI parameters when initiating a simulation.
 
+# Other commands
+
+Besides running simulations, this tool offers further commands allowing to download and analyze validator data:
+
+```
+Commands:
+  run         Runs a simulation
+  download    Downloads valdiator data
+  seat-stats  Prints seat stats
+  help        Print this message or the help of the given subcommand(s)
+```
+
 # Development
 
 Notes regarding the development workflow can be found in [`Development.md`](./Development.md).

--- a/sim-validator-assignment/src/config.rs
+++ b/sim-validator-assignment/src/config.rs
@@ -37,6 +37,13 @@ pub struct Config {
     pub include_partial_seats: bool,
 }
 
+/// Returns the number of (full) seats that can be claimed by `stake`.
+pub fn seats_per_stake(stake: u128, stake_per_seat: u128) -> u64 {
+    // Integer division in Rust returns the floor as described here
+    // https://doc.rust-lang.org/std/primitive.u64.html#method.div_euclid
+    u64::try_from(stake / stake_per_seat).expect("seats per stake should fit u64")
+}
+
 impl Config {
     #[cfg(test)]
     pub fn new_mock(include_partial_seats: bool) -> Self {
@@ -51,11 +58,9 @@ impl Config {
         }
     }
 
-    /// Returns the number of (full) seats that can be claimed by `stake`.
+    /// Convenience wrapper around [`seat_per_stake()`].
     pub fn seats_per_stake(&self, stake: u128) -> u64 {
-        // Integer division in Rust returns the floor as described here
-        // https://doc.rust-lang.org/std/primitive.u64.html#method.div_euclid
-        u64::try_from(stake / self.stake_per_seat).expect("seats per stake should fit u64")
+        seats_per_stake(stake, self.stake_per_seat)
     }
 
     /// Returns the amount of seats for all shards that must be filled by validators.
@@ -140,7 +145,7 @@ impl Config {
 mod tests {
     use std::collections::BTreeMap;
 
-    use super::Config;
+    use super::{seats_per_stake, Config};
     use crate::validator::tests::new_test_raw_validator_data;
     use crate::validator::{
         new_ordered_partial_seats, new_ordered_seats, parse_raw_validator_data,
@@ -148,10 +153,10 @@ mod tests {
 
     #[test]
     fn test_seats_per_stake() {
-        let config = Config::new_mock(false);
-        assert_eq!(config.seats_per_stake(20), 0);
-        assert_eq!(config.seats_per_stake(100), 1);
-        assert_eq!(config.seats_per_stake(530), 5);
+        let stake_per_seat = 100;
+        assert_eq!(seats_per_stake(20, stake_per_seat), 0);
+        assert_eq!(seats_per_stake(100, stake_per_seat), 1);
+        assert_eq!(seats_per_stake(530, stake_per_seat), 5);
     }
 
     #[test]

--- a/sim-validator-assignment/src/config.rs
+++ b/sim-validator-assignment/src/config.rs
@@ -58,11 +58,6 @@ impl Config {
         }
     }
 
-    /// Convenience wrapper around [`seat_per_stake()`].
-    pub fn seats_per_stake(&self, stake: u128) -> u64 {
-        seats_per_stake(stake, self.stake_per_seat)
-    }
-
     /// Returns the amount of seats for all shards that must be filled by validators.
     pub fn total_seats(&self) -> u64 {
         u64::from(self.num_shards)

--- a/sim-validator-assignment/src/config.rs
+++ b/sim-validator-assignment/src/config.rs
@@ -163,7 +163,8 @@ mod tests {
     #[test]
     fn test_collect_seats_for_shard() {
         let config = Config::new_mock(false);
-        let (_, validators) = parse_raw_validator_data(&config, &new_test_raw_validator_data());
+        let (_, validators) =
+            parse_raw_validator_data(&new_test_raw_validator_data(), config.stake_per_seat);
         // Using ordered seats as input to have a deterministic result of `collect_seats_for_shard`.
         let seats = new_ordered_seats(&validators);
 
@@ -184,7 +185,8 @@ mod tests {
     #[test]
     fn test_collect_seats_for_shard_errors() {
         let config = Config::new_mock(false);
-        let (_, validators) = parse_raw_validator_data(&config, &new_test_raw_validator_data());
+        let (_, validators) =
+            parse_raw_validator_data(&new_test_raw_validator_data(), config.stake_per_seat);
         let seats = new_ordered_seats(&validators);
 
         insta::assert_debug_snapshot!(config.collect_seats_for_shard(4, &seats));
@@ -195,7 +197,8 @@ mod tests {
     fn test_collect_partial_seats_for_shard() {
         let mut config = Config::new_mock(true);
         config.stake_per_seat = 90;
-        let (_, validators) = parse_raw_validator_data(&config, &new_test_raw_validator_data());
+        let (_, validators) =
+            parse_raw_validator_data(&new_test_raw_validator_data(), config.stake_per_seat);
         // Using ordered partial seats as input to have a deterministic result of
         // `collect_partial_seats_for_shard`.
         let partial_seats = new_ordered_partial_seats(&validators, config.stake_per_seat);
@@ -223,7 +226,8 @@ mod tests {
     #[test]
     fn test_collect_partial_seats_for_shard_errors() {
         let config = Config::new_mock(true);
-        let (_, validators) = parse_raw_validator_data(&config, &new_test_raw_validator_data());
+        let (_, validators) =
+            parse_raw_validator_data(&new_test_raw_validator_data(), config.stake_per_seat);
         let partial_seats = new_ordered_partial_seats(&validators, config.stake_per_seat);
 
         insta::assert_debug_snapshot!(

--- a/sim-validator-assignment/src/main.rs
+++ b/sim-validator-assignment/src/main.rs
@@ -8,6 +8,8 @@ mod mocks;
 mod partial_seat;
 mod run;
 mod seat;
+mod seat_stats;
+use seat_stats::{print_seat_stats, SeatStatsConfig};
 mod shard;
 use run::run;
 mod validator;
@@ -28,6 +30,8 @@ enum Command {
     Run(Config),
     /// Downloads valdiator data
     Download(DownloadConfig),
+    /// Prints seat stats
+    SeatStats(SeatStatsConfig),
 }
 
 fn main() -> anyhow::Result<()> {
@@ -35,5 +39,6 @@ fn main() -> anyhow::Result<()> {
     match args.command {
         Command::Run(config) => run(&config),
         Command::Download(dl_config) => download(&dl_config),
+        Command::SeatStats(ss_config) => print_seat_stats(&ss_config),
     }
 }

--- a/sim-validator-assignment/src/run.rs
+++ b/sim-validator-assignment/src/run.rs
@@ -16,7 +16,8 @@ pub fn run(config: &Config) -> anyhow::Result<()> {
         None => mock_validator_data(),
     };
 
-    let (population_stats, validators) = parse_raw_validator_data(config, &raw_validator_data);
+    let (population_stats, validators) =
+        parse_raw_validator_data(&raw_validator_data, config.stake_per_seat);
 
     println!("population_stats: {:?}", population_stats);
     println!(

--- a/sim-validator-assignment/src/run.rs
+++ b/sim-validator-assignment/src/run.rs
@@ -3,12 +3,11 @@ use crate::partial_seat::ShuffledPartialSeats;
 use crate::seat::ShuffledSeats;
 use crate::shard::Shard;
 use crate::validator::{
-    new_ordered_partial_seats, new_ordered_seats, parse_raw_validator_data, RawValidatorData,
+    new_ordered_partial_seats, new_ordered_seats, parse_raw_validator_data, read_validator_data,
+    RawValidatorData,
 };
 use num_rational::Ratio;
 use num_traits::ToPrimitive;
-use std::fs::read_to_string;
-use std::path::Path;
 
 pub fn run(config: &Config) -> anyhow::Result<()> {
     let raw_validator_data = match &config.validator_data {
@@ -82,13 +81,6 @@ pub fn run(config: &Config) -> anyhow::Result<()> {
         config.num_blocks, config.num_shards, num_corrupted_shards, config.num_blocks * u64::from(config.num_shards)
     );
     Ok(())
-}
-
-/// Reads validator data from a file exptected to contain `Vec<RawValidatorData>` serialized as
-/// JSON.
-fn read_validator_data(file_path: &Path) -> anyhow::Result<Vec<RawValidatorData>> {
-    let file_content = read_to_string(file_path)?;
-    serde_json::from_str::<Vec<RawValidatorData>>(&file_content).map_err(|err| err.into())
 }
 
 fn mock_validator_data() -> Vec<RawValidatorData> {

--- a/sim-validator-assignment/src/seat_stats.rs
+++ b/sim-validator-assignment/src/seat_stats.rs
@@ -1,0 +1,84 @@
+use clap::Args;
+use num_rational::Ratio;
+use num_traits::ToPrimitive;
+use std::path::PathBuf;
+
+use crate::{
+    config::seats_per_stake,
+    partial_seat::PartialSeat,
+    validator::{
+        new_ordered_partial_seats, parse_raw_validator_data, read_validator_data, Validator,
+    },
+};
+
+#[derive(Args, Debug)]
+pub(crate) struct SeatStatsConfig {
+    /// The amount of stake required to get one seat.
+    #[arg(long)]
+    pub stake_per_seat: u128,
+    /// The file from which validator data is read. It is expected to contain a vector of
+    /// `RawValidatorData` serialized as JSON.
+    #[arg(long)]
+    pub validator_data: PathBuf,
+    /// Whether to print stats for partial seats.
+    #[arg(long, default_value_t = false)]
+    pub include_partial_seats: bool,
+}
+
+pub(crate) fn print_seat_stats(config: &SeatStatsConfig) -> anyhow::Result<()> {
+    let raw_validator_data = read_validator_data(config.validator_data.as_path())?;
+    let (population_stats, validators) =
+        parse_raw_validator_data(&raw_validator_data, config.stake_per_seat);
+
+    println!(
+        "stake/malicious_stake\t{:.4}",
+        Ratio::new(population_stats.stake, population_stats.malicious_stake)
+            .to_f64()
+            .unwrap(),
+    );
+    println!("num_seats\t{}", population_stats.seats);
+    println!("num_malicious_seats\t{}", population_stats.malicious_seats);
+    println!(
+        "malicious_seats/seats\t{}",
+        Ratio::new(population_stats.malicious_seats, population_stats.seats)
+            .to_f64()
+            .unwrap()
+    );
+
+    if config.include_partial_seats {
+        print_partial_seat_stats(&config, &validators);
+    }
+
+    Ok(())
+}
+
+fn print_partial_seat_stats(config: &SeatStatsConfig, validators: &[Validator]) {
+    let partial_seats = new_ordered_partial_seats(validators, config.stake_per_seat);
+    let malicious_partial_seats = partial_seats
+        .iter()
+        .filter(|ps| ps.get_is_malicious())
+        .cloned()
+        .collect::<Vec<PartialSeat>>();
+    let sum_weights = sum_partial_seat_weights(&partial_seats);
+    let sum_malicious_weights = sum_partial_seat_weights(&malicious_partial_seats);
+
+    println!("num_partial_seats\t{}", partial_seats.len());
+    println!(
+        "num_malicious_partial_seats\t{}",
+        malicious_partial_seats.len()
+    );
+    println!(
+        "equivalent_num_seats\t{}",
+        seats_per_stake(sum_weights, config.stake_per_seat)
+    );
+    println!(
+        "equivalent_num_malicious_seats\t{}",
+        seats_per_stake(sum_malicious_weights, config.stake_per_seat)
+    );
+}
+
+fn sum_partial_seat_weights(partial_seats: &[PartialSeat]) -> u128 {
+    partial_seats
+        .iter()
+        .fold(0, |acc, ps| acc + ps.get_weight())
+}

--- a/sim-validator-assignment/src/validator.rs
+++ b/sim-validator-assignment/src/validator.rs
@@ -62,9 +62,7 @@ pub struct PopulationStats {
     /// Sum of stake of malicious validator stakes.
     pub malicious_stake: u128,
     /// Total number of seats of all validators. Note that some stake might not participate in
-    /// validation if it is not assigned to a seat. For example, if a validator has a stake of 17
-    /// and seat price is 5, then the validator holds 3 seats (worth 15 stake) and 2 stake remain
-    /// unassigned.
+    /// validation if it is not assigned to a seat and partial seats are disabled.
     pub seats: u64,
     /// The number of seats held by malicious validators.
     pub malicious_seats: u64,

--- a/sim-validator-assignment/src/validator.rs
+++ b/sim-validator-assignment/src/validator.rs
@@ -1,5 +1,7 @@
 use num_rational::Ratio;
 use serde::{Deserialize, Serialize};
+use std::fs::read_to_string;
+use std::path::Path;
 
 use crate::config::seats_per_stake;
 use crate::partial_seat::PartialSeat;
@@ -10,6 +12,13 @@ pub struct RawValidatorData {
     pub account_id: String,
     pub stake: u128,
     pub is_malicious: bool,
+}
+
+/// Reads validator data from a file exptected to contain `Vec<RawValidatorData>` serialized as
+/// JSON.
+pub(crate) fn read_validator_data(file_path: &Path) -> anyhow::Result<Vec<RawValidatorData>> {
+    let file_content = read_to_string(file_path)?;
+    serde_json::from_str::<Vec<RawValidatorData>>(&file_content).map_err(|err| err.into())
 }
 
 pub fn parse_raw_validator_data(


### PR DESCRIPTION
Adds a subcommand to print stats regarding the seats of a validator set:

```
cargo run -p sim-validator-assignment -- seat-stats --help

Prints seat stats

Usage: sim-validator-assignment seat-stats [OPTIONS] --stake-per-seat <STAKE_PER_SEAT> --validator-data <VALIDATOR_DATA>

Options:
      --stake-per-seat <STAKE_PER_SEAT>
          The amount of stake required to get one seat
      --validator-data <VALIDATOR_DATA>
          The file from which validator data is read. It is expected to contain a vector of `RawValidatorData` serialized as JSON
      --include-partial-seats
          Whether to print stats for partial seats
  -h, --help
          Print help
```

Target `seat-stats` in the Makefile provides an example.

Can be reviewed commit-by-commit.